### PR TITLE
Add make install-deps command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.3.0 - 2026-01-04
+
+### Features
+
+- Add `make install-deps` to install age and sops automatically
+  - age via apt
+  - sops v3.11.0 via .deb from GitHub releases
+  - Idempotent (skips if already installed)
+
 ## v0.2.0 - 2026-01-04
 
 ### Features

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,16 @@ Other homestak tools find site-config via:
 2. `../site-config/` sibling directory
 3. `/opt/homestak/site-config/` fallback
 
+## Dependency Installation
+
+```bash
+sudo make install-deps  # Install age and sops
+```
+
+Installs:
+- `age` via apt
+- `sops` v3.11.0 via .deb from GitHub releases
+
 ## Config Generation
 
 Run on a PVE host to bootstrap configuration:

--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ Only `secrets.yaml` is encrypted - all other config is non-sensitive.
 
 1. Install dependencies:
    ```bash
+   sudo make install-deps
+   ```
+
+   Or manually:
+   ```bash
    apt install age
    # Install sops from https://github.com/getsops/sops/releases
    ```
@@ -103,6 +108,7 @@ Only `secrets.yaml` is encrypted - all other config is non-sensitive.
 
 | Command | Description |
 |---------|-------------|
+| `make install-deps` | Install age and sops (requires root) |
 | `make setup` | Configure git hooks, check dependencies |
 | `make host-config` | Generate hosts/{hostname}.yaml from system info |
 | `make node-config` | Generate nodes/{hostname}.yaml from PVE info |


### PR DESCRIPTION
## Summary

Add Makefile target to automatically install dependencies (age and sops).

## Features

- `make install-deps` installs both tools automatically
- age via apt
- sops v3.11.0 via .deb from GitHub releases
- Idempotent (skips if already installed)
- Requires root/sudo

## Test plan

- [x] Non-root error message works
- [x] Tested on mother.core - correctly detected both tools already installed

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)