### PR TITLE
v0.13: Add postures and extend site.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,8 @@ secrets.yaml
 nodes/*.yaml
 !nodes/nested-pve.yaml
 
-# Encrypted secrets (gitignored by default for public template)
-# Remove these lines if you want to commit encrypted secrets to a private fork
-secrets.yaml.enc
+# Encrypted secrets (committed to enable sharing with private forks)
+# The plaintext secrets.yaml is still gitignored above
 
 # Editor files
 *.swp

--- a/envs/ansible-test.yaml
+++ b/envs/ansible-test.yaml
@@ -2,6 +2,9 @@
 # Purpose: Validate lae.proxmox, DebOps, geerlingguy roles
 # Node specified at deploy time via: run.sh --host <name>
 ---
+# Security posture: FK -> postures/dev.yaml
+posture: dev
+
 vmid_base: 10100
 
 vms:

--- a/envs/dev.yaml
+++ b/envs/dev.yaml
@@ -2,6 +2,9 @@
 # Primary key derived from filename: dev.yaml -> dev
 # Node specified at deploy time via: run.sh --host <name>
 ---
+# Security posture: FK -> postures/dev.yaml
+posture: dev
+
 # VM ID allocation: base + index (omit for PVE auto-assign)
 vmid_base: 10000
 

--- a/envs/k8s.yaml
+++ b/envs/k8s.yaml
@@ -2,6 +2,8 @@
 # Primary key derived from filename: k8s.yaml -> k8s
 # Node specified at deploy time via: run.sh --host <name>
 ---
+# Security posture: FK -> postures/prod.yaml (k8s should be hardened)
+posture: prod
+
 # VM ID allocation: omit vmid_base for PVE auto-assign
 # vms: (K8s cluster VMs to be defined in future phase)
-{}

--- a/envs/nested-pve.yaml
+++ b/envs/nested-pve.yaml
@@ -2,6 +2,9 @@
 # Primary key derived from filename: nested-pve.yaml -> nested-pve
 # Node specified at deploy time via: run.sh --host <name>
 ---
+# Security posture: FK -> postures/dev.yaml
+posture: dev
+
 # VM ID allocation: base + index (omit for PVE auto-assign)
 vmid_base: 99800
 

--- a/envs/test.yaml
+++ b/envs/test.yaml
@@ -2,6 +2,9 @@
 # Primary key derived from filename: test.yaml -> test
 # Node specified at deploy time via: run.sh --host <name>
 ---
+# Security posture: FK -> postures/dev.yaml
+posture: dev
+
 # VM ID allocation: base + index (omit for PVE auto-assign)
 vmid_base: 99900
 

--- a/hosts/pve.yaml
+++ b/hosts/pve.yaml
@@ -6,3 +6,8 @@ access:
   ssh_user: root
   authorized_keys:
     - jderose@studio    # FK -> secrets.ssh_keys["jderose@studio"]
+
+# Optional: non-root user for user.yml playbook
+# Uncomment and set to create a local user with sudo access
+# local_user: homestak
+# local_user_shell: /bin/bash

--- a/postures/dev.yaml
+++ b/postures/dev.yaml
@@ -1,0 +1,14 @@
+# Development security posture
+# Permissive settings for development/testing environments
+---
+ssh_port: 22
+ssh_permit_root_login: "yes"
+ssh_password_authentication: "yes"
+sudo_nopasswd: true
+fail2ban_enabled: false
+
+# Additional packages for development
+packages:
+  - net-tools
+  - strace
+  - tcpdump

--- a/postures/local.yaml
+++ b/postures/local.yaml
@@ -1,0 +1,11 @@
+# Local execution security posture
+# For on-box ansible execution (no remote SSH)
+---
+ssh_port: 22
+ssh_permit_root_login: "prohibit-password"
+ssh_password_authentication: "no"
+sudo_nopasswd: true
+fail2ban_enabled: false
+
+# No additional packages
+packages: []

--- a/postures/prod.yaml
+++ b/postures/prod.yaml
@@ -1,0 +1,11 @@
+# Production security posture
+# Hardened settings for production environments
+---
+ssh_port: 22
+ssh_permit_root_login: "no"
+ssh_password_authentication: "no"
+sudo_nopasswd: false
+fail2ban_enabled: true
+
+# No additional packages for prod (minimal attack surface)
+packages: []

--- a/secrets.yaml.enc
+++ b/secrets.yaml.enc
@@ -1,0 +1,28 @@
+#ENC[AES256_GCM,data:qOO7FxuG/7XNI7/oI6STTkngbysQ1iGtrCK5Ginm4GIrOjEGmmIRmdE8cDPfR/5F5CmYC3pQtEI=,iv:joVitev3wD2fAGap3FF/RYvdn+3Q3TyPh7zWeKC6pTw=,tag:8gcmEsfMMU4ZDYJXwIKYUw==,type:comment]
+#ENC[AES256_GCM,data:5e/d1vE9iGSc3JSycth0oyU/aZkpTT/Eoh2oKLvK5dUPZtpnvouzPPlJKu2e2a5a5OyGHc4Q6ol9,iv:pMpLZK+F4V9dXpYGV3rd6+J6+c9U6wrbQ1YA9vf6+s8=,tag:MHrKhC5uOAVOcPE2yggqww==,type:comment]
+api_tokens:
+    father: ENC[AES256_GCM,data:wLOpOGcAUHL7kVgkHNnskIYpBaA9/3N2MxzVAEkxUbc7sxWg8bLS8nHOLzVjLtS70fM=,iv:204V4JGc/Ghj3FfaXQahoVKiICZviFxl2ziM9evqWwI=,tag:Pv6VygkwE8TUy7MiP2xinw==,type:str]
+    mother: ENC[AES256_GCM,data:gbGvJwopZdop0C9DArp1XbbJ9ip2vBaiBwKGZnIHdlFEVvprWN0rmgIz08fThRaJ06U=,iv:23ZhhGS8UXzKo35YSodNyg7OKTyQ5rN8I7jj0duT9o0=,tag:TcifPpbcGIZB2oNhmHjOnA==,type:str]
+    nested-pve: ENC[AES256_GCM,data:bzz+TBzL0BzPpQle5Rd8dtmSqdrQbxbYZ44y,iv:Tw8EeBzgJ76G0qCzw+dHgm2QMt59wuQQ0VKksbY80Oc=,tag:dMIZzB7K7nzK6GuaaW6ukw==,type:str]
+passwords:
+    vm_root: ENC[AES256_GCM,data:4/n+akkDLFTkn78kpYC+0mqsvNPSD15WkSmecx/l8GZT/Ca9hSSZOfW3aBK+OttiEn3jO/IiBOSxUEsDVoXNYduDqhftdm84gCLT2D+sPy8X0d3eRuGr4dwcg12ZeAj5HxjP9h70Hd8YI8VFbkq+qrX1gEKJW9Vq,iv:wFqjeJvVAWYDKmuOjWSILZ+CMfrda5QKyJmgUeRx3hY=,tag:ZSAaSaQq2UpFNEPtYLAiHw==,type:str]
+ssh_keys:
+    #ENC[AES256_GCM,data:OqpN02oUJrXp6moUx/TagDUDlcVR62aTlrrE4R90MNbpVi9kEpW9oBmreNB4i/Tq6DFSSeLUdFmh/pkvdpW1,iv:ttA6zig3v/fhTEo+2GLdyr3v5omPaJP/V7y12uev1/w=,tag:1QDDlgXxcb8E8U7yiZ9Jrw==,type:comment]
+    jderose@studio: ENC[AES256_GCM,data:MjFohSQggFuKFrx2oqVjingJ3NKM5xFHLG46leBaRgW/PqyI7J7yx31e/xSw/uea5bCqVYYGyVNZ,iv:Xy0VKD5T2LhNKsy02awQlauz+G4V3yVMDIvN8yuhRWE=,tag:PIREZtkc0XTKiwANpCxuKg==,type:str]
+    jderose@father: ENC[AES256_GCM,data:tg1/UBrz2T7HsexWdRCzzdfZxQEXKTnPrE6WhT2a7W87qvcGvt55zRHYXYFh5JMPxtAtr0J3HYhRjv+puxbVwUXONF5wg39zg8/kOls1W6zyNfnFiWXLas7G9e/emDe/eM8Nf5cym5GEDxpeWdZ3TS7KAwl8zYxmlnm3grpOV7F9YJzAMDf159HngXfQfS1vKU8bPRw/XMJTnOvLtU9OFB7TTvcdHqEOo19ZoQaeTz3CEfrWYsl93Js+5eWrK8DHd8BPIUcDXNgSsPzl39gV0310W7CiuqP46pJrBM2kzV9wqOluUzX2bLXhiivkIakUSRMwa6FiWhrL0gYvs9aDFZoGg2bXBz1UP/9j2Wz6IpL9VWPmETiZKTUniBIYo1BSg83dw2KdW62q5wIVVTPun03eRntTKn6KqmSnrEaK6bCLOLiRid64e01pFrjFdH9MWkoQ4nZzQOpJi8ef5K/twwIimEYgIX/pA9jvD+pMucoUiT/ehVJhwJXCbSHMVbtRTDWGwNNsrGVLki58sAV2HTfuOEDYMZUBzvrQP8f0yUNuBWEzQGa7fszmwTUTVkSPcyAKVCFI5eNSY4ImoHqG64DFBeASH6dT78LPNkb5kiievOGvMQTONKMBaMIlklAkswABH3fQccOZI7g+DuT3P218zrHYBfRn2yI73ng3rk+2gxRODKfpItCqJxNqPl2nkAQj1mmKf8Tz8gIJjOxTfi1lr0u0EhPJ5xUe/J553aqcGD5adevt,iv:lvQEYA0QJSjshbDHJdAaPiKPx6hktGYKrAB+bfCDlng=,tag:wFgvy+J8/dHqgIDjn7s/9A==,type:str]
+    root@pve: ENC[AES256_GCM,data:C2CicFIWziARfWfMtDzM/JP4qOtCFYHOy9d/xWxD151cxe2I9hDCHboSTq7GvuijSUEQ,iv:s2ohQ06I4TJVdTkKb5xJVOA1wTWFyyDQJsW/oZpbFeE=,tag:tM+RXv0iVbipkHY6yWy1LA==,type:str]
+sops:
+    age:
+        - recipient: age19g7xlyf8fndus5zzh72w7hlac28fzefwasa2rh6aju74eyh2tq8q2jhc2g
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaK2doNWdKck82ME1xTWtV
+            Qjl2MHQvQzYzdWR2MkN0RGJwcUFINUhHUzBNClQxNklxNnFxZUcxQXAzN1hCSG52
+            Tjh3K1NDWG5iNW5JRjJqYUZJckhsc1kKLS0tIEZNbDF1MjBiZ1FkR2paeGVBakVF
+            eTlyTDJ3cWduZWdNTXJXclN1VFpOSzgKu9Yw0LvVlAvBFdA0cUkArHgA16OBXjnA
+            H03H099jqvollTjvhCPXHsJoBGpbl+k5ItWV1xEQpZAHrpcFTvvC3A==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-01-06T20:12:27Z"
+    mac: ENC[AES256_GCM,data:tVJs1Jxirg5DDo6n6gZDsljKMG+T18RauqMj/KelliQ5LWdn03bPlONcWHHFugi4FcYxFm6qEclrd4f7ac5MGJVVlv7j2Odw6P38ITAED+tbeGViNIq0V8Co3qzLOBw8SG6vpsFCP+X44GgaqlrT/RVlcgNgHH1KTUB0YU7cR5E=,iv:UxRb9K3c02mVkT1hk8mFpLs2v6dNnomyGdoUsAOJ9/0=,tag:biEqEMeI2kXSotRjVnDn4A==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.11.0

--- a/site.yaml
+++ b/site.yaml
@@ -4,7 +4,23 @@
 defaults:
   timezone: America/Denver
   domain: local
-  datastore: local-zfs
+  # datastore removed in v0.13 - now required in nodes/*.yaml
+  # Run 'make node-config FORCE=1' to regenerate node configs
   ssh_user: root
   bridge: vmbr0
   gateway: 10.0.12.1
+
+  # Base packages installed on all VMs
+  packages:
+    - htop
+    - curl
+    - wget
+    - git
+    - vim
+    - tmux
+    - tree
+    - jq
+    - rsync
+
+  # Proxmox settings
+  pve_remove_subscription_nag: true


### PR DESCRIPTION
## Summary
- Create `postures/` directory with dev, prod, local security profiles
- Extend `site.yaml` with packages and pve_remove_subscription_nag
- Add posture FK to all `envs/*.yaml` files
- Add local_user example to `hosts/pve.yaml` template
- Update `.gitignore` to allow `secrets.yaml.enc`
- Update CLAUDE.md for 5NF entity model with postures
- Add datastore to `nodes/father.yaml` (now required per-node)

## Test plan
- [x] Integration test: nested-pve-roundtrip passed (301.7s)
- [x] Unit tests: 28 config_resolver tests passed

Closes #29, #27, #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)