### PR TITLE
docs: Add packer_release default and latest-centric note (#83)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,8 +67,11 @@ Non-sensitive defaults inherited by all entities:
 - `defaults.gateway` - Default gateway for static IPs
 - `defaults.packages` - Base packages installed on all VMs
 - `defaults.pve_remove_subscription_nag` - Remove PVE subscription popup (bool)
+- `defaults.packer_release` - Packer release for image downloads (default: `latest`)
 
 **Note:** `datastore` was moved to nodes/ in v0.13 - it's now required per-node.
+
+**Packer images:** The `latest` release is the primary source for packer images. Most versioned releases don't include images; automation defaults to `packer_release: latest`. Override with a specific version (e.g., `v0.20`) only when needed.
 
 ### secrets.yaml
 ALL sensitive values in one file (encrypted):

--- a/secrets.yaml.enc
+++ b/secrets.yaml.enc
@@ -1,28 +1,28 @@
-#ENC[AES256_GCM,data:9qQ4QQOvNkXLkVKATbzHB5iwpKw92zgybk0depN/CbmfHXaiOkLCd/NNC/Ph1b7fvB0FllFaEPc=,iv:Z1mmt8wAxokOltLJuT+255a4HAy8VO4icZXKuCp0rZg=,tag:jmdKjgrXSjWXVMakvQstuw==,type:comment]
-#ENC[AES256_GCM,data:f7Fp7VLEqJt/sNjupRUS77iOMTWXK4ffP9NTG4Xg36Y2HmzmM6BDqMttTd0NzlA4i0ncZ4nXzJBW,iv:9Js7CzIZZ9tlcrfSZhZg79bw5WG7sKk6uP3BzRNWYQs=,tag:xSxK4oEEf7uhRCuIlTagjA==,type:comment]
+#ENC[AES256_GCM,data:1r8m/siaDrhbFA1NAoQ+qknB3eLj31N0i5vDP36+tHNbxgZFEqxYKV68LuINHL/9ccvarFlY0jU=,iv:H6haH/gHiFqFJadOQDbI8F/sOftYGHqJxsm4ayIPSGY=,tag:J9z8GtVa73C/2MV/LKh+BQ==,type:comment]
+#ENC[AES256_GCM,data:j/lBtKVNssDyhOHHlfLPqpurUVEhtDEv2im+tyfRhBVEjCNjG2QEss6RS7LDPZhEgNX0oedjEYQ3,iv:/OFBT+sBOp29nNDql78VyKokb/0iZdXX4p1p7+fkx2s=,tag:0fXXBPr8dTBmFLgm6VGLtQ==,type:comment]
 api_tokens:
-    father: ENC[AES256_GCM,data:cxY2YYEYe8n5lpD/rzv0OEqoRuYTHJg+s7hylwGs6C6dqyVv6apwDDbZ7kBuLvnxKCZ1EYEV,iv:ZpPvO/fHsMNpySOU5KOyXQ0PTbMed3qmkuhpmtnk0Fg=,tag:QSLosLhfJinn4iKtKiIsFw==,type:str]
-    mother: ENC[AES256_GCM,data:WZnGl7uFSBVynBvphc74LGmjK9ord0FPzEFVet753n1fNfF/sPySn/VzoGTOiKD5I1g=,iv:a4jNPG3uEoBZ/M7zFLoFDzzX52KcVdpThRSWUjObhak=,tag:Lz75QqoJ3aJD+nGyZE/F+A==,type:str]
-    nested-pve: ENC[AES256_GCM,data:mrKZMRpKpts4DR3uICpLCwZTVGswHMkXSlnCnJCCJg==,iv:/dyUZBeGf02jTArPNO/t536/A5zjygZMJS5NZicMEoM=,tag:ZKR+tCslVNm9l/hZ23N3Qw==,type:str]
+    father: ENC[AES256_GCM,data:mFdvjUnf9vM2dAk39Uyk4OBOhpsptQUDeSxVGtS4lPnQ1Wo3OT6sHZNZwq+iYJYn4qrfpMX9,iv:yANJZkBT5ISkvfbP7N/4DeTnmF1YmsuFtlVek6Atq+s=,tag:l0+uSMGpagikMZ5OA94ozg==,type:str]
+    mother: ENC[AES256_GCM,data:fufuXXpFyKP4cqj7a9HBNqUREeQ2iV5292zcsChrZDfWbyH7e8QYoFwbMDEUAQyp22o=,iv:eC84PgEI+lejpF9rPbbuNXy/VimJPex9tFPpGiM+6wk=,tag:2hJ4ybTfpVXKd9eGy5pAUw==,type:str]
+    nested-pve: ENC[AES256_GCM,data:aXRMa00GV48iWTZS7SE7QXs6i+TsqVYA053jAJegbg==,iv:DWg/NNj71bjMpLR611MtwCHlOUo8STlhQpLSqDn/MBE=,tag:nxeSX/xlxGkCmsaHDNpcbA==,type:str]
 passwords:
-    vm_root: ENC[AES256_GCM,data:Sj/4pB6thf8pBculnTNM21SKU8CabxABg6AVMMUoEIiehRw0VYXxoQyO3pQgtw7koZqaf6POhUo/TzPOzrI/BPVubKJCAz5SykgKj+WOSq9zdFUfEL6aE5XOS7bxetu9zsm+edxCTVMosRiW7lrRS+fYeoe+nGlb,iv:MQbpEM6Zd7a0HO9hBctBAGlDDI6pyt8OfOtKt7W/PAc=,tag:rDMuGxMizn5/V4HaYz5spg==,type:str]
+    vm_root: ENC[AES256_GCM,data:60VOCW3kDGTzvqgoENDSIguXxNzU2l3wWoHbDmefATuKDfQkZiEqN50FEGrahF2DI4K4DC+B/gw7rfUQ+yvePtLsrEDtiBy5xxHKk4+SqqRzYM5+4bQAO56h42yPLnGu41Wx1/hIFfbYtBsvI1PlSpDrAUs+P3O8,iv:WWopE77NLmjOpZSXlcThFnqBCoBQSf/BhgdC0PA8KrI=,tag:GD99eEM0zi1/RnW5RXCkjA==,type:str]
 ssh_keys:
-    #ENC[AES256_GCM,data:weIFS0eCzPyvlstUZdX4N2zTK7Cd1x5YG/tHF6KWY/MMXgpBc11OK0ldXGH8/70/Sez4BJs7MeZLC/jyuUGS,iv:iMn5eQ0wK8fMQxeGfwn7MinPgedxCSxHbxut1/TKjV4=,tag:d1LroZJ1m6DJvlQOwASUTQ==,type:comment]
-    jderose@studio: ENC[AES256_GCM,data:juEu1g+jsAnyWNqwicX3c5kl9ewGnml1i3+MoCnphZkCH6qAQDSYHZGGwuUnAasFKVg+CY1dn2+f,iv:zqHRdQc3IpuY11w4YbRM8l5lqZCzBA+QTRjmzv8qzcs=,tag:e4CQjtq3FU9oHkHytT4Xrw==,type:str]
-    jderose@father: ENC[AES256_GCM,data:ANFBFombHou89/aY4GEf7BQDvYpYeAdEXRsMbNwJVXq4w2M8MOa2Lqm3n9Qri6e01rNzR3/KZ+3nbIAVmRyfHYih2QLQv6QuXGfHRPyXXaO22xBNRmF7duV0TSreyrbdEjJtwYccJL6QTq7vgXMxcnZgspCOag4O0xiMEEeRdFLWC6GcyvdXiiI3cHI8rbVg/tKMVwbQFuf2q7AA/0bbosEgTU8mYx4GEWCtHqno/9zF53qYrVrIWNI1SHqgz9D9xtjwJP1+Bq7nDWXjIQ1r9VPAqf52yOEQlfUSd5C0+RipcxskKs4fVlFCmLrjmJmJJ2HxlPydpy21HmD0g+JML7UE8zrmoB2esntF0sYyePoAyzi9pfnqNiAXdQaIP6AegeEjWD0l1aNO/kSwBvYiQK35LnDlnrOu7kYkRJW7527/5lp024yxN1A92udfip8wjNnNEwSy9N5TVLQSlXUV6dyxtpOkaFxydP6GkSIlvVt5Q/s7kSnHTg/m9Wc++vw9BkOSoYkAcRAHkffFbxYrlKpBF/sA/VZEgMc5NmT9M/3hkqpEMqEVDrIAFkHNx30m9Gye4aq71a4BvVDW6qn2HkBIxuaDybjcnHlSY/Gz/Zc7jHMYeNUqH5K+d+d4Jyr9kYft5E1uJSDpEPVICLIAbWWD+tXR9lCuswJ11lIJ5nU3XjMngLmlk5YC2wSrme6V6Z0iVYckr6GGeiXlBp7KFxW5sY/aW2UBcsexHevBRhLaLqlkMlyO,iv:WibFM0sMJLOIyNIAuITwPNwdORnjxEpUdPiIKrxYSyU=,tag:XBo2CszOvu9ASfaBVeVmMw==,type:str]
-    root@pve: ENC[AES256_GCM,data:+CKEO9o7KBdVEONvEjT8A0N2zNNZygI5SXrc8sjWnx4TwUHuhDElLr+YzMGV/4EYHLWi,iv:YiVOCDjAp80Jm3W89WMjlZChNLQ/DOKMCJnhUozpVcs=,tag:n00aZ8n+ZwMpdt0rmRCNxg==,type:str]
+    #ENC[AES256_GCM,data:b5HUvPxI+EgnI/dqJ37LUOnF8//YWFin5NLDjvSR3RjdPSf064ngglDKB7jbDiAkPDkT2eBVjzHA+2YfU0+9,iv:TNbrATJmYaSk8adGLSB2yVB3faG+elMSFJhTQZxk3Og=,tag:ETDnNS8s1ktMsegP/bcd9A==,type:comment]
+    jderose@studio: ENC[AES256_GCM,data:0PcSEbzwg86Jh6in2PL8qB2YbDeltNRCnFn2t6yniHt+CRV5rYtiCrihY3Tj89sP8Y187lFBmeVi,iv:VyTEMcpkRY2VI0dbFjImqdEhIusUqpkN+q9DZgc9ZWU=,tag:Kf/OSt/gAesP8V/Ys6RZEQ==,type:str]
+    jderose@father: ENC[AES256_GCM,data:7hKdExPahDDSdj+n1it8HaaQrQBX8Vio/r70Pj7fzxsD1y+kAQeEme1Dg8+RIw0Q+Sya0navFFL7whwr5EwTW94L2kILT/+AQo83y28uDApSnr5/1fUxBUYjaIljDtDpN5gvGm4Ge8EGQlpEEsoeTzEn5EPAyHFjBT/Hty32yoAdGnQ4mw5XA5TzWRI9cNougCXoQumCbK2G9FqqpDkYDBkv1B99GRL7MLqhFJZlX9zsu329RsosmbnnF4n6NsCGOi3LlBNGdTxuQZt4A+vSw5/HPgNXAbvhrnhapl4sobD5jqLHp4Xn8c76UM1snRP/VTY7zj/deuokoll4w4djPFFd2niUGl6bEoQTr6e/Vu9MPnKGPzhMtc8f/b3xTzy/nRLH5WjjSXyb2KAlsIlUL7MjQXJhN0Kqg4UzXRyZCY6eNJAVe2VVSqhDhDDn2E9Nf0KufJCuoBSNtXtJbmFjBZevOzKqEVPNcXKCN0sfSL/IHJfb0Zy+BzhwVB0onrSvU7X3G5NWzx11J730sGpJEl9dqhSig4P819elLkDc8JUKxyrafuhjSRKUN53eLvwaoEmN0PtRfhGqL13caX73Jp1Dfaig6ATcypQh80RQzYlKGUoku7ZIpGGaYUNdGyQkeTkCg7O1dwjybXXdgAmZlkoXnMhrMTGxbv+SCd1bVbCGBiQWyeHq9HO7vrtQ0ajFBm5bn/WOALlZjj1rIQVEnOJNGuaHVZxe11vK2R84t5IcverOoe4M,iv:j5ePxlVHPWq9sRUbwXvZRnwDaIpHJAr6ICmvxK39y1U=,tag:LQQUP9kC3yIaTW3JjwftEw==,type:str]
+    root@pve: ENC[AES256_GCM,data:HnyqOk2x6NiQyHQW1JyG1pE7YGfnE9kyq+rh6Vu4Eiz0RgDoHB0S8UpIWPi2e9867HIv,iv:lKSC8YkbbxpUXxANXirFchKbF+WsKlQI+7Lk/PZ3XxU=,tag:pg0tkNaj4AYuxxiRbPmo1g==,type:str]
 sops:
     age:
         - recipient: age19g7xlyf8fndus5zzh72w7hlac28fzefwasa2rh6aju74eyh2tq8q2jhc2g
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA4R0RkSitlRHBSaGZDRTNu
-            SGxjbGp4MFRWUGhtUU5iakRTcnM4cytVWnkwClUzUFVISmJTVmx5Q0R5NUV4c0px
-            N0ZKMjVGb3dPL1ltK0hoVE9mYjhXR1kKLS0tIC9BeVZsR012cWwyck9sQXRQbWFx
-            aWh3T25tVFZBOTRGQUN6Z3JiOXRnMHcKubRkxQPCQDIOtjMcIG19bOEV0tYCbM0z
-            CeW0goN3iBPYMRZosuZ0G5EpkffQzFb1F6nFwAh6sHt1K62qEmU+ew==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrVWJ4a0hwWExTMW50SlRC
+            ZVZYcE80SnRNMjU4OXlhRDJsNGdCbVhacXdBCmJZRWJLRWJrcTJKVVMwQy81eVdC
+            Y0JNcUJ4Ulg3UzV1ZEg1WUR1K1RZR2sKLS0tIGtsUFNjRS9STHJpYS9jVVI4K1Bq
+            QTJRSkh3M1htdy96NmNIbFFER2dMUHcKrHSgoxk/+Y34yGLX7kkcKY6KOZJUdZGn
+            NzdDxBVklztBKILkIXjr76cI9Y9UK+7KtTKYidOaQQ9HObvkxZwXbQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-01-11T23:42:10Z"
-    mac: ENC[AES256_GCM,data:BMklLYR4qxh77JoXG8/zOi0OybJlNrXRbQsgTBq79zG63KfHqErG7t1+L9aKj+msGSlq3SsI+YvhWam0G6H0BuYYGKedE7sHHFHeqWhvOPkZj5uO4njSN2nItoPk5qJWn3mxOgH4i9ZYC0JxYTXC1Ruuz2r4QV2s2XJElIFY9n8=,iv:T/dsCTpRp6HDsh8V4Iv0TuvbZW3e5IweB3+VGdQ2QdM=,tag:m0wqIVR2/4RYxYJCUkb89A==,type:str]
+    lastmodified: "2026-01-15T16:50:21Z"
+    mac: ENC[AES256_GCM,data:c3mHSiIRYt+Rxpd/Jtu4/96oLQeMQUhgjsSGBSBpiEQOJP8x/iLXp2LFDEQ+b+TDzDonV1Se5MC36EI8K/qmc69YivATNTKLP2ULTpFcqSkbqXRzKJ/YMf+o/SWnB0RdhPNTp3qIpobimmcJWIYMgxZY0aqasoNqzTvX6WQJEYE=,iv:YKDiMuS4ZwA2Qv1r9+4RS+SKQIa0tBwg59QVPrTgB78=,tag:F4BciS/TbS99GFchNTgF2A==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0


### PR DESCRIPTION
## Summary

Documents the `packer_release` default and explains the latest-centric image distribution approach.

## Changes

- Add `defaults.packer_release` to site.yaml documentation (default: `latest`)
- Add note explaining that `latest` is the primary image source
- Clarify that versioned releases typically don't include images

## Related

Part of homestak-dev#83 (Adopt latest-centric packer image distribution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)