### PR TITLE
feat(cli): Add standard flags to config scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,6 +213,10 @@ make node-config   # Generate nodes/{hostname}.yaml from PVE info
 # Force overwrite existing files
 make host-config FORCE=1
 make node-config FORCE=1
+
+# Direct script usage (supports --help, --force)
+./scripts/host-config.sh --help
+./scripts/node-config.sh --force
 ```
 
 `host-config` gathers: domain, network bridges, ZFS pools, hardware (CPU/RAM), SSH settings

--- a/scripts/host-config.sh
+++ b/scripts/host-config.sh
@@ -1,18 +1,61 @@
 #!/bin/bash
 # Generate hosts/{hostname}.yaml from system inventory
-#
-# Usage: ./scripts/host-config.sh [FORCE=1]
-#
-# Gathers:
-#   - Network bridges (vmbr*) with IPs and ports
-#   - ZFS pools and devices
-#   - SSH access config
 
 set -e
 
+show_help() {
+    cat << 'EOF'
+host-config.sh - Generate hosts/{hostname}.yaml from system inventory
+
+Usage:
+  host-config.sh [options]
+  make host-config [FORCE=1]
+
+Options:
+  --help, -h    Show this help message
+  --force, -f   Overwrite existing config file
+
+Environment Variables:
+  FORCE=1       Same as --force (for make compatibility)
+
+Description:
+  Generates a hosts/*.yaml configuration file by gathering system information:
+  - Network bridges (vmbr*) with IPs and ports
+  - ZFS pools and devices
+  - SSH access configuration
+  - Hardware info (CPU cores, memory)
+
+  Run this on each physical host to bootstrap its configuration.
+
+Examples:
+  ./scripts/host-config.sh              # Generate config (fails if exists)
+  ./scripts/host-config.sh --force      # Overwrite existing config
+  make host-config FORCE=1              # Via Makefile
+EOF
+    exit 0
+}
+
+# Parse arguments
+FORCE="${FORCE:-0}"
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --help|-h)
+            show_help
+            ;;
+        --force|-f)
+            FORCE=1
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            echo "Use --help for usage information." >&2
+            exit 1
+            ;;
+    esac
+done
+
 HOSTNAME=$(hostname -s)
 OUTPUT_FILE="hosts/${HOSTNAME}.yaml"
-FORCE="${FORCE:-0}"
 
 # Check if file exists
 if [ -f "$OUTPUT_FILE" ] && [ "$FORCE" != "1" ]; then


### PR DESCRIPTION
## Summary

- Add `--help`, `--force` to `host-config.sh` and `node-config.sh`
- Support both CLI flags and env vars (`FORCE=1`) for Makefile compatibility
- Update `CLAUDE.md` documentation

## Usage

```bash
# CLI flags
./scripts/host-config.sh --help
./scripts/host-config.sh --force

# Makefile usage (env var)
make host-config FORCE=1
```

## Test plan

- [x] `./scripts/host-config.sh --help` shows help text
- [x] `./scripts/node-config.sh --help` shows help text
- [x] `--force` flag works for overwriting existing files
- [x] `FORCE=1` env var still works for Makefile compatibility
- [x] Bash syntax validation passes

## Related Issues

- Part of homestak-dev#116 (CLI standardization epic)
- Closes #36 (--help for config scripts)

🤖 Generated with [Claude Code](https://claude.ai/code)