### PR TITLE
docs: Document iac-driver hosts/ fallback resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Documentation
+- Document iac-driver hosts/ fallback resolution in CLAUDE.md
+  - `--host X` now falls back to `hosts/X.yaml` when `nodes/X.yaml` doesn't exist
+  - Enables provisioning fresh Debian hosts before PVE is installed
+
 ## v0.32 - 2026-01-19
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,17 @@ Primary key derived from filename (e.g., `father.yaml` → `father`).
 
 **Git tracking:** Site-specific host configs are excluded from git via `.gitignore`. Generate your host config with `make host-config` on each physical host.
 
+**iac-driver usage (v0.36+):** When `--host X` is specified and `nodes/X.yaml` doesn't exist, iac-driver falls back to `hosts/X.yaml` for SSH-only access. This enables provisioning fresh Debian hosts before PVE is installed:
+```bash
+# Create host config on fresh Debian machine
+ssh root@<ip> "cd /usr/local/etc/homestak && make host-config"
+
+# Provision PVE using hosts/ config (no nodes/ yet)
+./run.sh --scenario pve-setup --host daughter
+
+# After pve-setup, nodes/daughter.yaml is auto-generated
+```
+
 ### nodes/{name}.yaml
 PVE instance configuration for API access.
 **Important:** Filename must match the actual PVE node name (check with `pvesh get /nodes`).


### PR DESCRIPTION
## Summary

Document the new `--host` fallback behavior added in iac-driver#66:
- `--host X` now falls back to `hosts/X.yaml` when `nodes/X.yaml` doesn't exist
- Enables provisioning fresh Debian hosts before PVE is installed

## Type of Change
- [x] Documentation

## Changes
- `CLAUDE.md`: Add iac-driver usage note to hosts/ section
- `CHANGELOG.md`: Add Unreleased section

## Testing
N/A - documentation only

## Related Issues
Supports iac-driver#66 (v0.36 release)

## Checklist
- [x] CHANGELOG.md updated
- [x] CLAUDE.md updated

---
🤖 Generated with [Claude Code](https://claude.ai/code)