### PR TITLE
feat(v2): Add auth model for Specify phase (#152)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,15 @@
 - Add `v2/` directory structure for lifecycle architecture (#152)
   - `v2/defs/spec.schema.json` - JSON Schema for specifications
   - `v2/defs/node.schema.json` - JSON Schema for nodes
+  - `v2/defs/posture.schema.json` - JSON Schema for postures
   - `v2/specs/` - Specifications (pve.yaml, base.yaml)
-  - `v2/postures/` - Security postures (replicated from v1)
+  - `v2/postures/` - Security postures with auth model
   - `v2/presets/` - Size presets with `vm-` prefix
   - `v2/nodes/` - Node templates with unified type model
+- Add auth model for Specify phase (#152)
+  - Posture-based auth: dev (network), stage (site_token), prod (node_token)
+  - Node-level auth override via `auth.method` and `auth.token`
+  - New `stage` posture for pre-production environments
 
 ### Changed
 - Rename lifecycle phases for clarity (#152)

--- a/v2/defs/node.schema.json
+++ b/v2/defs/node.schema.json
@@ -164,6 +164,22 @@
         }
       },
       "additionalProperties": false
+    },
+    "auth": {
+      "type": "object",
+      "description": "Authentication for Specify phase (overrides posture default)",
+      "properties": {
+        "method": {
+          "type": "string",
+          "enum": ["network", "site_token", "node_token"],
+          "description": "Auth method: network (trust boundary), site_token (shared), node_token (per-node)"
+        },
+        "token": {
+          "type": "string",
+          "description": "FK to secrets.yaml auth.site_token or auth.node_tokens.{value}"
+        }
+      },
+      "additionalProperties": false
     }
   },
   "allOf": [

--- a/v2/defs/posture.schema.json
+++ b/v2/defs/posture.schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://homestak.dev/schemas/posture.v1.json",
+  "title": "Posture Schema v1",
+  "description": "Defines a security posture for nodes",
+  "type": "object",
+  "properties": {
+    "auth": {
+      "type": "object",
+      "description": "Default authentication for Specify phase",
+      "properties": {
+        "method": {
+          "type": "string",
+          "enum": ["network", "site_token", "node_token"],
+          "default": "network",
+          "description": "Default auth method for nodes using this posture"
+        }
+      },
+      "additionalProperties": false
+    },
+    "ssh": {
+      "type": "object",
+      "description": "SSH daemon configuration",
+      "properties": {
+        "port": {
+          "type": "integer",
+          "default": 22,
+          "description": "SSH port"
+        },
+        "permit_root_login": {
+          "type": "string",
+          "enum": ["yes", "no", "prohibit-password"],
+          "description": "Root login policy"
+        },
+        "password_authentication": {
+          "type": "string",
+          "enum": ["yes", "no"],
+          "description": "Password auth policy"
+        }
+      },
+      "additionalProperties": false
+    },
+    "sudo": {
+      "type": "object",
+      "description": "Sudo configuration",
+      "properties": {
+        "nopasswd": {
+          "type": "boolean",
+          "default": false,
+          "description": "Allow passwordless sudo"
+        }
+      },
+      "additionalProperties": false
+    },
+    "fail2ban": {
+      "type": "object",
+      "description": "Fail2ban configuration",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable fail2ban"
+        }
+      },
+      "additionalProperties": false
+    },
+    "packages": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Additional packages for this posture"
+    }
+  },
+  "additionalProperties": false
+}

--- a/v2/postures/dev.yaml
+++ b/v2/postures/dev.yaml
@@ -1,11 +1,19 @@
 # Development security posture
 # Permissive settings for development/testing environments
 ---
-ssh_port: 22
-ssh_permit_root_login: "yes"
-ssh_password_authentication: "yes"
-sudo_nopasswd: true
-fail2ban_enabled: false
+auth:
+  method: network  # Trust network boundary
+
+ssh:
+  port: 22
+  permit_root_login: "yes"
+  password_authentication: "yes"
+
+sudo:
+  nopasswd: true
+
+fail2ban:
+  enabled: false
 
 # Additional packages for development
 packages:

--- a/v2/postures/local.yaml
+++ b/v2/postures/local.yaml
@@ -1,11 +1,19 @@
 # Local execution security posture
 # For on-box ansible execution (no remote SSH)
 ---
-ssh_port: 22
-ssh_permit_root_login: "prohibit-password"
-ssh_password_authentication: "no"
-sudo_nopasswd: true
-fail2ban_enabled: false
+auth:
+  method: network  # Local execution, trust network
+
+ssh:
+  port: 22
+  permit_root_login: "prohibit-password"
+  password_authentication: "no"
+
+sudo:
+  nopasswd: true
+
+fail2ban:
+  enabled: false
 
 # No additional packages
 packages: []

--- a/v2/postures/prod.yaml
+++ b/v2/postures/prod.yaml
@@ -1,11 +1,19 @@
 # Production security posture
 # Hardened settings for production environments
 ---
-ssh_port: 22
-ssh_permit_root_login: "no"
-ssh_password_authentication: "no"
-sudo_nopasswd: false
-fail2ban_enabled: true
+auth:
+  method: node_token  # Per-node unique tokens
+
+ssh:
+  port: 22
+  permit_root_login: "no"
+  password_authentication: "no"
+
+sudo:
+  nopasswd: false
+
+fail2ban:
+  enabled: true
 
 # No additional packages for prod (minimal attack surface)
 packages: []

--- a/v2/postures/stage.yaml
+++ b/v2/postures/stage.yaml
@@ -1,0 +1,21 @@
+# Staging security posture
+# Moderate security for staging/pre-production environments
+---
+auth:
+  method: site_token  # Shared site-wide token
+
+ssh:
+  port: 22
+  permit_root_login: "prohibit-password"
+  password_authentication: "no"
+
+sudo:
+  nopasswd: false
+
+fail2ban:
+  enabled: true
+
+# Debugging tools for staging
+packages:
+  - net-tools
+  - strace


### PR DESCRIPTION
## Summary

Adds authentication model for the Specify phase, with auth method determined by posture.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Changes
- Add `auth` section to `node.schema.json` (method + token override)
- Add `v2/defs/posture.schema.json` with auth, ssh, sudo, fail2ban sections
- Add `stage` posture for pre-production (site_token auth)
- Update existing postures with nested structure and `auth.method`:
  - dev: `network` (trust boundary)
  - local: `network` (on-box)
  - stage: `site_token` (shared)
  - prod: `node_token` (per-node)
- Document auth model flow in CLAUDE.md

## Auth Model

| Posture | Auth Method | Token Source |
|---------|-------------|--------------|
| dev | network | none |
| local | network | none |
| stage | site_token | secrets.auth.site_token |
| prod | node_token | secrets.auth.node_tokens.{name} |

## Testing
- Schema structure validated manually
- Auth implementation deferred to v0.47 (Specify Infrastructure)

## Related Issues
Closes homestak-dev#152

## PR Readiness Checklist

See [50-merge.md](https://github.com/homestak-dev/homestak-dev/blob/master/docs/lifecycle/50-merge.md) for full guidance.

- [x] Feature tested end-to-end (schema structure)
- [x] External tool assumptions verified (N/A - schema only)
- [x] CHANGELOG entry in this PR
- [x] CLAUDE.md updated (auth model section)
- [ ] Performance claims measured (N/A)
- [x] Prerequisites documented (implementation in v0.47)
- [x] Integration test scenario identified (N/A - schema only)