### PR TITLE
docs: Document secrets.yaml auth token structure (#152)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 ### Documentation
 - Document v2 structure in CLAUDE.md
+- Document secrets.yaml auth token structure
 - Update lifecycle phase terminology
 
 ## v0.41 - 2026-01-31

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,6 +271,18 @@ ALL sensitive values in one file (encrypted):
 - `api_tokens.{node}` - Proxmox API tokens
 - `passwords.vm_root` - VM root password hash
 - `ssh_keys.{user@host}` - SSH public keys (identifier matches key comment)
+- `auth.site_token` - Shared token for stage posture (v0.43+)
+- `auth.node_tokens.{name}` - Per-node tokens for prod posture (v0.43+)
+
+**Auth tokens (v0.43+):**
+```yaml
+# secrets.yaml structure for Specify phase authentication
+auth:
+  site_token: "shared-secret-for-staging"  # Used by stage posture
+  node_tokens:
+    dev1: "unique-token-for-dev1"          # Used by prod posture
+    dev2: "unique-token-for-dev2"
+```
 
 ### hosts/{name}.yaml
 Physical machine configuration for SSH access and host management.


### PR DESCRIPTION
## Summary

Documents the `secrets.yaml` structure for auth tokens used in the Specify phase.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Refactoring
- [x] Documentation
- [ ] Other

## Changes
- Add `auth.site_token` and `auth.node_tokens.{name}` to secrets.yaml documentation
- Add example YAML structure showing auth token format
- Update CHANGELOG documentation section

## Related Issues
Closes homestak-dev#152

## PR Readiness Checklist
- [x] CHANGELOG entry in this PR
- [x] CLAUDE.md updated