### PR TITLE
Sprint 171: v0.45 Foundation (Config)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,6 +261,7 @@ Non-sensitive defaults inherited by all entities:
 - `defaults.packages` - Base packages installed on all VMs
 - `defaults.pve_remove_subscription_nag` - Remove PVE subscription popup (bool)
 - `defaults.packer_release` - Packer release for image downloads (default: `latest`)
+- `defaults.spec_server` - Spec server URL for Create → Specify flow (v0.45+, default: empty/disabled)
 
 **Note:** `datastore` was moved to nodes/ in v0.13 - it's now required per-node.
 

--- a/secrets.yaml.enc
+++ b/secrets.yaml.enc
@@ -1,27 +1,37 @@
-#ENC[AES256_GCM,data:8bTgGCyt20tBQraqFdRNxDJ9d3Bkb+piNnpiMqaTWo4xsFEMde3ajGlJ4UBmARg63pXXXV1jxMk=,iv:PUDUCF2GJr1Ula2OeOtW3L64/+B+/3ULxPe+jenKlvg=,tag:noL85olvPOQ7FeItR5jOag==,type:comment]
-#ENC[AES256_GCM,data:ilduv3vBeCf3bjQQJkYliRZU+hrjV0SalvHpAOpgyvopvA0gBc2+GzCQUGn8Y4yElbOuDPPiva/x,iv:NRyLSNOrgaOrGcH1txNjg1gJPI1KjOXtRD2HyZUivOI=,tag:6p2w2A+mgg8r245im9/e4Q==,type:comment]
+#ENC[AES256_GCM,data:q0J5HE+prNiAg1vlHXip+gZgCSP61eeCRDVzkB8PwVpRW4v+EAzV7/Z/4WCuKCeeZuqA6e9HwlY=,iv:+4I/TklkyKL4+JYhz7SVHMaiUhos4JYzW+AohAb4d04=,tag:OSqxxDsr2BtuQn4viy5GmQ==,type:comment]
+#ENC[AES256_GCM,data:a5imYCvgIZ/eWB17cLb2L22O7DBNsFwh7KEXuyTA6maehMG/6CrLFuinGGLR9Cse9X/x/sRd52ML,iv:Wu12VbbDs48OUcnwf1qDjUpvdzqhXoetbfPY6440SqA=,tag:v0QKMv5DH+JJIn9nGt830w==,type:comment]
 api_tokens:
-    father: ENC[AES256_GCM,data:fMvkl5JwBsR1XJv9u1OtltXCZMNivJaO2+wssULYwpqepHdycvIeCYQOWW1AeOU78LbTss6R,iv:TMhi15LzDA/oPXnmZ2VUTuQ/G0J/4L0vhDNunyejZQ0=,tag:X8p2r8ZzZ/cHi3JoV4GBoA==,type:str]
-    mother: ENC[AES256_GCM,data:Id0vWguqF2n0MQrNRYhjbIIrbjTzhoCgNwEvYKoz2/d0Acd8LnlZIRMI46gIjLJfVVA=,iv:Jeb2gcGNwUO982lDS/lIpKBBnWvHZxoRanpM+PQClHY=,tag:N/Q0BKpo4X3+aMYlEXiVDg==,type:str]
-    nested-pve: ENC[AES256_GCM,data:s0G45ovFF8TR2z4Cr5QL4OX1EWWdZLzpmgdEsSBsCw==,iv:4k3A2/B3L4mLdJMgQT9MNbgYTZ1jfU375n9PymJ9txY=,tag:MNVIA+U2BDpPgIcpxZ4MsQ==,type:str]
+    father: ENC[AES256_GCM,data:1IDc2T+T8BtGJoM6pRDh7PDz9jAfUISNRKdL9bjoJ+ktSYyOChhiTI7ilV29Op5ATgSZG3vj,iv:9Tuj/TW4Gi2NRK79uoW9QmIQNnnnAMnBp4GMRcXJHKM=,tag:rCAvooTj1/av+tbPNdRXQA==,type:str]
+    mother: ENC[AES256_GCM,data:f/ISwKaunv4kRhrbqDaWExn3DaDSagAw4RSxpS8zoGADd8r5VCjBWYjqGN8YL3p8Qk0=,iv:hocpuT/MOGJFdHJ/zc22+csybBhDwKblNtXg8sOtKqg=,tag:raqd+waPreQ3xTDUWdJRfA==,type:str]
+    nested-pve: ENC[AES256_GCM,data:bMsg/Ws+CqNg6LJWp71kjGZy86yvpV4rxxPDE5eVRQ==,iv:5SkuD9Aq9AtK0JdoRsRqUEAoditId4ebK6VPpe2LQXQ=,tag:l2Zm8FEQmEcykLJrYnmFCA==,type:str]
 passwords:
-    vm_root: ENC[AES256_GCM,data:uRUf94HWR+/9xy1jVUozjv8+Hx1j4G4fvMSpMslU/Ab461Ysy4E6Wb5T+4luOImr1va3SssZMlxWaeBp7uzzwQH2oje9dVwcliovga+jQDgKy2UBAOJAeUuixUHhbnDlBReuIri+tE/JclzhFvalHVyKu1hJeIo9,iv:j/9w6qRnd+upySaKrx5p5UxiWPoeTyPyK4Qv3RTwCkY=,tag:bBDj9h3LM1kU7gPR0LC/cA==,type:str]
+    vm_root: ENC[AES256_GCM,data:+lsBcYBm9IMj0mHJcNkDprlMOSoPatSlvUVfUBWeFUMV4xTVvEtwUw8SIy7VIVz18pQb1XqBU5JCAdsQxyZF110c4rRphBLlnm68t11g3OVS8z+7YZqzprrGkcYylNcL5/Yf1oozSq38n8nbN17I3xvGONtfAL9a,iv:rUA6JQ6guqxma9tId6sMZbbgbAAvvwrR29xcuN+6+20=,tag:aDIN4JBNITSoaf0YtcH+4A==,type:str]
 ssh_keys:
-    #ENC[AES256_GCM,data:/FRZ/IZ6vLaugt0FsnwdmjuuEwQNXDnfI4R0OCJc6NgX08slQJYyl4WFyfmqUEaEA+TSvzPG0AutafANIPmL,iv:m3oC03q0noBQpk17I4oQosDr2U0OUqioa5UiUaZUVt8=,tag:ZvVbzYAgUR30ktbKcZskDg==,type:comment]
-    #ENC[AES256_GCM,data:rRkDyUxw2yXcRsI+e0ER7jdep1DaL4bl/2kAeLuVnDid6e3W0qylxxqioegFtJheP5K7buYQcrKPGETAu8APbG9lLuFZZaAOcPSHySKnxXhfT/OgEw==,iv:7C7m2UVYH4kE7m7u7D0BNadOn4u0W0/+ybP2fRsrVSs=,tag:sv1k1jO/wJrJ7J2pZyL8Fg==,type:comment]
-    jderose@father: ENC[AES256_GCM,data:xknBD2ZcMp1gwHmkCSAmzUv0hBo6t/U1PYUyzzeZchqEs+t8U88ErVyyBtJwMkqA21wc8DE2hfyo/m+eATfUm93eHptKgbL7JdiVgAa3wClwDf5FeEXAB/LGZoqTWIv4B5Nxmar51ggWit7Nnj7Zrs+AgE1euiu3AiuPbfenrQrFodJdj+6TB5qlDl3AH7zvnrWEydUC9wdPHAF2+ioft84LXuxc2COi+I/wRDlmLYw2vZirVjEz1F/9L1OayvVwH+9ngNJjHPcCSquyP/wXGWuPE1wHylntCN4kimgQCcTgY8QI//BS5j80a0vpZ5FIAir4AZ9Bx8uGIt5pyBPYLzd9D56Y8GAvjTpMx8CySUBxLHtvuB+OlUBYphoWmYvSVy63N9H+jqyKFxBJwuhsDkcSofhMIQJS2IdRQ2skcM+EZzmYrC22y9QEL6R+Z792ADM4t41XYhAcpVUMM6GWzG/3uKI6uzlntVz+dMYVPwH4seGVDVIl0qjfIaFJofLsWBObSz4TMbbjPeN8WQ6iyct6Oy1uUSeETXa56HFte0jefOTh5EVDnTlc404UHqIG8R43tWOuidDptsyJ1FO/SgD3Aus2I0FXH9Z48WaPuFR2kIPzk9vgzeWJcgUqVY0d6zzfFT/EpB3PCRSxmNapmGtNdxktLyWoClDBvkGX6OpncWrEowbm5A5FyzSiiKh9lKC7+u4Aj9LtI7n5Bw17z+Rcra98G1xr2U3TAkH7q/gXSz9gZHx8,iv:ZVNNnQzdtcoIpMbBf+I5Rmq2w21zWn8JigT53L89jos=,tag:T+/AkXpR91pERcEc3TYsIA==,type:str]
+    #ENC[AES256_GCM,data:gRO6Z+ukbZNIer+zFL9eXHMvQyMUBEG6t0vkJfcjvHr5ccv2M4VwAjWIigIyplqksBPYvnJe0NcTqj6FtTaq,iv:PgkNy8Qu9liURZkU4uIueCzCq5Zb6o3UJn3ilk+x3F0=,tag:8PKnhhRlMabL3ux3IzvRrA==,type:comment]
+    #ENC[AES256_GCM,data:Ze/T/wCR29vRlthXEeOharsmSBA2OuGY8EOWHa0fWYgYIJvIc3LFMYdMrWCPVCky7hk0fBtdFLVLuWB+WMd/8F4ogtpKDe12LjxTgL2oT5a4JekXew==,iv:i17/Psl0vqi2uQ3Ic4sRKPvGUqt+HlSDVuH5bjYRsnA=,tag:xkwG42QlSu/uuPTYntxXTg==,type:comment]
+    jderose@father: ENC[AES256_GCM,data:wSzATpdBSJVfJVf2x789VhC4F6OA6356411ZxlG94rUTc0Eem5nXn5ORPdBRT9Zp2ZFZPgVekPFGkrebBmliF/kPH6YJL6aT2eN+7iGBkHQFeKhhzoa5KOTLKpVvEviQ5f2rs8XrM9FSNIR+hvk03uPtjCko8UDRcpKbFktUmVgQ02jvDrwUNZ0TrkXlicCAwdpyX5LSMkgQZrVWTXP7Qz3rVTJnA1VwoXPwJeEngXmNfBWXz6KzshVZpfzQavB85VxC06GEiKKg2uyH+cBhzfSmo2Hprtt8TGsNTiTyvXailqdS7hGJe38wppd3WOXPQhbTxL26zIT071/caYM5MCbQmL9+uvhPiFnulHJPkF+0Z5M0sdocc86oaR9NtKh4WLP5DhhKEWbOyTFuKD1SCcWYaxdDeHlTTiBjLgJT0EOfEfXeh/9RxnIfMpAXJi4VExbxZYhrNQwICldeF6Y+z83860fWqivxkAObXyh0Ydc34Xmj1hxScj7fXjS7B0RfF2kqH3IVZrRL2uErKIAnRJ3nidxCCj5sHRXeFl0sTAobq2GzbT+9XN5c6fE1axn3P4Nmzoc+x9yejEB4ucZOmqdUlEqMVyfkMsGkjKKJyin2H2kkzqP5xwOX06FM1wNcEU+GAgmUw5KauZjEBzssIlt+eWwjF5HIvyy5z5tqxlCIOGc6C0ayQJkjir8atZ02kNH6y5YAGWZYFftexfEHeJxjrRPKMNwKtIOhIY5Hi8StjgzSmCDD,iv:GiiJWgbhw5po9kvmOiwieHnolDTydeRBoI9SOPWSw9c=,tag:R8gex9ww7CF4LanvVwmRiQ==,type:str]
+#ENC[AES256_GCM,data:rOISpU5etGac/2U+DKllWL164v3fLc13sSreS1Y7o8vROnm5uyAKAM8wE6AOCajiPg==,iv:X6b5wfcZl6K6Cv+Kj4FRZLhTiUxmkvEHefk66GO9guY=,tag:N44mHShQuVTsGioRgW6A+g==,type:comment]
+#ENC[AES256_GCM,data:4+uvuF0o2qQ5byLrFtrRYdhL++UMTCYzLMKYfR0=,iv:/S0HMp4EA55cmj2P891DbM32FRcijAugXUX1zA64/38=,tag:Z/1AQJCfj6Ug0cCCzvWLUg==,type:comment]
+#ENC[AES256_GCM,data:yk2W360ZJdlxbWKbl4ys3jgBogIc9FxaO4vm5LCPsUb4+Q==,iv:+ojp+GcV4BSgTjwN2CD3tLON7C549zvZ4DFe3eD9H4w=,tag:34qC3zxzUkdeXKa2vMt8jg==,type:comment]
+#ENC[AES256_GCM,data:wSGC3j7B7Uah/0In/ecurTEJPJT9d806U8eCRec=,iv:knHY4tP3js7DZXzw+utv5nKD8NOKfcuABozvaSP+dQs=,tag:43YpHRTcrjdzthlURaPJOQ==,type:comment]
+#ENC[AES256_GCM,data:zh6WJ7cbuacZP80mfkED0I4gAAD9AcUBxxFONIoQgmPMBcJXz9HUROe6,iv:w/wVk/vTAEJxKy5HWDszhABbzz6x+k1JA2WVl7CLo6g=,tag:Ex8DvLbpsdHuCl3aHjrJwA==,type:comment]
+auth:
+    #ENC[AES256_GCM,data:rK3hdRuK6NI5/jboH8Aa34lrIeHLoKb0f3qYPSYDaw==,iv:XI8N81Pf2jOBa4uL1oDF9BVsDCc9OS5CGch2MlRCCm4=,tag:ghWE+qh938iuMujKbLaSeA==,type:comment]
+    site_token: ""
+    #ENC[AES256_GCM,data:vVAQf4hVPLGYuzUMtmofmYLzskqJv7q5RQ9wwAUctgpnu7fiA/EUXIbS3RTIMvcKaw==,iv:IBGZC4XAmXJTtWNoTgcrvCYZ57uBLdjaynQMLj6rL+s=,tag:nvJl6WxMEFnMOU2TJrvnig==,type:comment]
+    node_tokens: {}
 sops:
     age:
         - recipient: age19g7xlyf8fndus5zzh72w7hlac28fzefwasa2rh6aju74eyh2tq8q2jhc2g
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxU3dyekZ2Z09hSTVTSDNv
-            c2JPclZRd001THV0WlVaZzF4MXNQMytNT0hVCnlWaVhqaEFqcnJ1QjlwanFVcFZx
-            eFRGQjlYQWh1Qzc2dTRQV1F5UmFwQ0UKLS0tIHFLdHRIZ3BEdG4wbGJlc0o2ZU4x
-            OEdKQzVPb1FMbHJkNzhkMHB4Wk1iR0UKWs8lkpqIVtC0ZpfqbRTpV/o4iR4CILnU
-            Ru4n8+i8VA70VK6FnSg7Q2zn+lNrbvLQ/6A6Ev644y6vj7T+cbbyCg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqdE9kQkttWUs4WmZvaHJE
+            ekg5SDBtbk01Z3ZOS1g4cEkwV1Y1eWdBbUFVCjRNU1NxVFA2TklaV3hXc281eTFw
+            L1lKWC96NHdEMnMrRTR1eDNvOVFLSG8KLS0tIG4wQjhlYnQwb09xNnloRmxUVGxO
+            Q0NmSC9pWjFoNmtiR3ZidmMvTWhhblkKUAJbe18I3l/oN1VzNVFmlZIBFLjk4kLU
+            xjdGJ+KH8elkH+//lc7gPg/ZFwx43THJWtHS9U0/sWIhF2UbBReNFA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-02-02T01:01:17Z"
-    mac: ENC[AES256_GCM,data:NSa1iZbW7fq7egl9B/0Y/SOAWwYWr6/9vn52ee3iwNWE4TMwMVXEZ5JBZIHugVjakxfzzghmsrfiRGfGBtzLDyjFQcUyUA6j5EjGQtgZGB3fQ89KEnl6ZUhNHr3buRb2i/COAqBSCRBIADyps2R8Ht7LaxbYVgYDNxoFp7rcBsM=,iv:hObchcm7w74TB1xg6bcqpOjT76CCdKKVmQ3YWCJc7Bc=,tag:ELWHFSdlr9/2whklLMX23Q==,type:str]
+    lastmodified: "2026-02-02T08:26:05Z"
+    mac: ENC[AES256_GCM,data:vFsKSCaO64cvbxoBoR6ZX0osw+kEP1Zuha1CUo4YmdiA84H4kilCUN4vTPnQ/L4A/QL8+YrlhRioQZ0f83L3pvLq5erm/Dtv7fy4GYmgrBt4ura83UDMKdD2LqJOngwy6SjmqvHV7bB9UlqDAtcVISSe4Pdc5oqY6ekj5Ho2DqQ=,iv:1+8DkXMUT7yr9z7YtMmXI5glKi9L0SrJm+PKQBcI5wc=,tag:GBEj+z0eFCARsODi4CqqqQ==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0

--- a/site.yaml
+++ b/site.yaml
@@ -27,3 +27,8 @@ defaults:
 
   # Proxmox settings
   pve_remove_subscription_nag: true
+
+  # Spec server for Create → Specify flow (v0.45+)
+  # Empty string means spec discovery disabled
+  # Set to "https://<controller>:44443" to enable
+  spec_server: ""


### PR DESCRIPTION
## Summary

Add spec_server and auth fields to support the Create → Specify flow in v0.45.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [x] Sprint merge

## Changes
- Add `defaults.spec_server: ""` to site.yaml
- Add `auth.site_token` placeholder to secrets.yaml
- Add `auth.node_tokens` section to secrets.yaml (empty map)
- Update CLAUDE.md with new field documentation

## Testing
- Unit tests: N/A (configuration only)
- Integration scenario: Manual validation
- Validation result: PASSED

```
1. spec_server in site.yaml: ✓
2. auth section in secrets.yaml: ✓
3. secrets encrypt/decrypt cycle: ✓
```

## Sprint Scope
- From homestak-dev#154 Sprint 1 scope

## Validation Evidence
- Scenario: Manual validation (config-only sprint)
- Result: PASSED
- Validation: secrets.yaml encrypts/decrypts correctly, all fields present

## Related Issues
Part of: homestak-dev#171
Refs: homestak-dev#154 (v0.45 Release)

## Checklist
- [x] Tests pass locally (secrets encrypt/decrypt)
- [x] Integration scenario passes
- [x] CLAUDE.md updated